### PR TITLE
Changed examples in getting started from python to python3

### DIFF
--- a/content/quickstart/getting-started/hsm4.md
+++ b/content/quickstart/getting-started/hsm4.md
@@ -118,9 +118,11 @@ Before moving on to Production mode, ensure your application is running correctl
 If you have any questions, feel free to create a new post here in the Community and we will get back to you.
 
 
-To test some of the API and see it's functionality, you can also run these pre-installed scripts:
-`python /usr/local/share/zymkey/examples/zk_app_utils_test.py`
-`python /usr/local/share/zymkey/examples/zk_crypto_test.py`
+To test some of the API and see it's functionality, you can also run these pre-installed scripts: 
+
+`python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`
+
+`python3 /usr/local/share/zymkey/examples/zk_crypto_test.py`
 
 ----------
 ## 7. Production Mode (permanent binding)

--- a/content/quickstart/getting-started/hsm6.md
+++ b/content/quickstart/getting-started/hsm6.md
@@ -119,9 +119,11 @@ Before moving on to Production mode, ensure your application is running correctl
 If you have any questions, feel free to create a new post here in the Community and we will get back to you.
 
 
-To test some of the API and see it's functionality, you can also run these pre-installed scripts:
-`python /usr/local/share/zymkey/examples/zk_app_utils_test.py`
-`python /usr/local/share/zymkey/examples/zk_crypto_test.py`
+To test some of the API and see it's functionality, you can also run these pre-installed scripts: 
+
+`python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`
+
+`python3 /usr/local/share/zymkey/examples/zk_crypto_test.py`
 
 ----------
 ## 7. Production Mode (permanent binding)

--- a/content/quickstart/getting-started/zymkey4.md
+++ b/content/quickstart/getting-started/zymkey4.md
@@ -270,9 +270,9 @@ Would you like the ARM I2C interface to be enabled? select  (Yes), enter, enter<
 <a href="https://docs.zymbit.com/quickstart/api">Go to API Documents &gt;</a>  </p>
 
 <h3 id="application-examples">Application Examples</h3>
-<p>The quickest way to get started is to see the various methods at work by running these scripts:
-<code>python /usr/local/share/zymkey/examples/zk_app_utils_test.py</code>
-<code>python /usr/local/share/zymkey/examples/zk_crypto_test.py</code></p>
+<p>The quickest way to get started is to see the various methods at work by running these scripts:</p>
+<p><code>python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py</code></p>
+<p><code>python3 /usr/local/share/zymkey/examples/zk_crypto_test.py</code></p>
 
 <p>More Resources:</p>
 <ul>


### PR DESCRIPTION
Examples for Zymkey4, HSM4, HSM6 changed to reference python3 instead of python(2). Cleaned up a little formatting but left Zymkey embedded HTML formatting. Needs cleanup at some point.