### PR TITLE
Workaround for bullseye repo missing

### DIFF
--- a/content/getting-started/hsm4/quickstart/index.md
+++ b/content/getting-started/hsm4/quickstart/index.md
@@ -96,7 +96,17 @@ For a bare Raspbian system, first login to your Pi.
 
 Then download and install the necessary Zymbit services onto your Pi. 
 `curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash`
+
+{{< callout warning >}}
+**Raspberry PI OS - Bullseye** We are working on pushing a repository to directly support the Raspberry PI OS Bullseye release (10/30/2021). In the meantime, the Zymbit Buster repo will work. Substitute the following curl command for our standard installation script to use the Zymbit Buster repo:
+
+`curl -G http://s3.amazonaws.com/zk-sw-repo/install_zk_sw_bullseye.sh | sudo bash`
+
+{{< /callout >}}
+
 (grab a cup of coffee because this will take between 4 and 20 minutes).
+
+
 
 ----------
 ## 6. Developer Mode (temporary binding)

--- a/content/getting-started/hsm6/quickstart/index.md
+++ b/content/getting-started/hsm6/quickstart/index.md
@@ -96,6 +96,14 @@ For a bare Raspbian system, first login to your Pi.
 
 Then download and install the necessary Zymbit services onto your Pi. 
 `curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash`
+
+{{< callout warning >}}
+**Raspberry PI OS - Bullseye** We are working on pushing a repository to directly support the Raspberry PI OS Bullseye release (10/30/2021). In the meantime, the Zymbit Buster repo will work. Substitute the following curl command for our standard installation script to use the Zymbit Buster repo:
+
+`curl -G http://s3.amazonaws.com/zk-sw-repo/install_zk_sw_bullseye.sh | sudo bash`
+
+{{< /callout >}}
+
 (grab a cup of coffee because this will take between 4 and 20 minutes).
 
 ----------

--- a/content/getting-started/zymkey4/quickstart/index.md
+++ b/content/getting-started/zymkey4/quickstart/index.md
@@ -149,7 +149,13 @@ Download and install the necessary Zymbit services onto your device.
 
 `curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash`
 
-Then, grab a cup of coffee, because this will take between 4 and 20 minutes.
+{{< callout warning >}}
+We are working on pushing a repository to directly support the Raspberry PI OS Bullseye release (10/30/2021). In the meantime, the Zymbit Buster repo will work. Substitute the following curl command for our standard installation script to use the Zymbit Buster repo:
+
+`curl -G http://s3.amazonaws.com/zk-sw-repo/install_zk_sw_bullseye.sh | sudo bash`
+
+{{< /callout >}}
+
 
 ## Test the installation
 

--- a/content/getting-started/zymkey4/quickstart/index.md
+++ b/content/getting-started/zymkey4/quickstart/index.md
@@ -150,7 +150,7 @@ Download and install the necessary Zymbit services onto your device.
 `curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash`
 
 {{< callout warning >}}
-We are working on pushing a repository to directly support the Raspberry PI OS Bullseye release (10/30/2021). In the meantime, the Zymbit Buster repo will work. Substitute the following curl command for our standard installation script to use the Zymbit Buster repo:
+**Raspberry PI OS - Bullseye** We are working on pushing a repository to directly support the Raspberry PI OS Bullseye release (10/30/2021). In the meantime, the Zymbit Buster repo will work. Substitute the following curl command for our standard installation script to use the Zymbit Buster repo:
 
 `curl -G http://s3.amazonaws.com/zk-sw-repo/install_zk_sw_bullseye.sh | sudo bash`
 

--- a/content/troubleshooting/general/index.md
+++ b/content/troubleshooting/general/index.md
@@ -12,6 +12,10 @@ toc: true
 
 ### **Known Issues**
 
+#### Raspbian OS Bullseye Release
+We will have a repository to directly support the Bullseye release (10/30/2021) of the Raspbian OS up shortly. In the meantime, the Zymbit Buster repo will work. Substitute the following curl command for our standard installation script,
+
+`curl -G http://s3.amazonaws.com/zk-sw-repo/install_zk_sw_bullseye.sh | sudo bash`
 
 #### HD Wallet
 Current Hierarchical Deterministic (HD) Wallet includes secp2561r1 (NIST P-256) and secp256k1 (ECC Koblitz P-256) support. ed25519 (Edwards Curve) is not currently supported (coming soon).


### PR DESCRIPTION
Workaround for bullseye repo missing. Added link to temporary install script for bullseye as well as warning box on Getting Started pages. TODO: Remove once we post the real bullseye repo.