### PR TITLE
Merge in changes to Getting Started

### DIFF
--- a/content/getting-started/hsm4/quickstart/index.md
+++ b/content/getting-started/hsm4/quickstart/index.md
@@ -78,9 +78,9 @@ For the Jetson, the Operating System - Tegra - is based on Ubuntu. The I2C bus i
 
 For Raspian-based operating systems, you must configure the state of the {{< term/i2c >}}.
 
-Log in to your Raspberry Pi and run sudo raspi-config.
-Navigate to Interfacing Options -> I2C -> Would you like the ARM I2C interface to be enabled?
-Select yes, and confirm this choice.
+Log in to your Raspberry Pi and run `sudo raspi-config`.  
+Navigate to Interfacing Options -> I2C -> Would you like the ARM I2C interface to be enabled?  
+Select yes, and confirm this choice.  
 Your {{< term/i2c >}} bus is now configured and ready to talk to the Zymkey. The default {{< term/i2c >}} address for the Zymkey is 0x30.
 
 {{< resource_link "troubleshooting/zymkey4/#q-how-do-i-set-an-alternative-i2c-address" >}} The default I2C address for Zymkey is 0x30. If this conflicts with another device in your system, you can reconfigure the Zymkey to use another address of your choice. {{< /resource_link >}}
@@ -126,8 +126,8 @@ Your HSM is now in Developer Mode. The binding is temporary and the HSM can be m
 Before moving on to Production mode, ensure your application is running correctly. 
 
 Explore our HSM resources for help: 
-* [Perimeter Detect](https://docs.zymbit.com/tutorials/perimeter-detect/hsm4)
-* [Encrypting your root file system](https://docs.zymbit.com/tutorials/encrypt-rfs/hsm4)
+* [Perimeter Detect](https://docs.zymbit.com/tutorials/perimeter-detect/hsm4/)
+* [Encrypting your root file system](https://docs.zymbit.com/tutorials/encrypt-rfs/)
 * [Encrypting & decrypting sensor data on disk](https://docs.zymbit.com/tutorials/sensor-data/)
 * [Using the Real Time Clock](https://docs.zymbit.com/reference/real-time-clock/)
 * [Zymbit APIs](https://docs.zymbit.com/quickstart/api/).
@@ -139,15 +139,15 @@ If you have any questions, feel free to create a new post in the Community and w
 
 When you are ready to deploy your system into the field we recommend that you permanently bind your HSM to a specific host device and SD card.
 
-##### **WARNING: THIS BINDING PROCESS IS PERMANENT AND CANNOT BE REVERSED. PAY ATTENTION TO THE FOLLOWING:**
-* Your specific HSM will be locked to the specific host device and it is impossible to move or bind your HSM to another host. There are no factory resets, masterkeys or other forms of recovery. 
+{{< callout destructive >}} THE BINDING PROCESS IS PERMANENT AND CANNOT BE REVERSED. PAY ATTENTION TO THE FOLLOWING:
 
-* If you are using the perimeter_detect features, the sequence in which you arm, disarm is very important in production mode. Be sure to follow the process steps below.
+Your specific HSM4 will be permanently locked to the specific host device.
+It will be impossible to move or bind your HSM4 to another device. There are no factory resets, masterkeys, or other forms of recovery.
+If you are using the Perimeter Detect features, then the sequence in which you arm and disarm this feature is very important. Be sure to carefully follow the process steps below.
+Once you have locked your HSM4 into production mode, Zymbit cannot guarantee its operation if you subsequently do a major distribution upgrade (e.g. Raspbian Buster to Bullseye). Contact Zymbit for more information.
+If you decide that you are not ready for permanent binding, leave the HSM4 in developer mode, but beware this makes it easier for a bad actor to replace the host with rogue hardware.
 
-
-* Once you have locked your HSM into production mode, Zymbit cannot guarantee its operation if you subsequently do a major distribution upgrade (e.g. Raspbian Jessie to Stretch). [Contact Zymbit for more information.](https://www.zymbit.com/contact-us/)
-
-* If you decide that you are not ready for permanent binding then leave it in developer mode, but beware this makes it easier for a bad actor to replace the host with rogue hardware.
+{{< /callout >}}
 
 ##### **Moving from Developer Mode to Production Mode**
 **Pre-binding Checklist**

--- a/content/getting-started/hsm4/quickstart/index.md
+++ b/content/getting-started/hsm4/quickstart/index.md
@@ -332,10 +332,4 @@ After bind locking the HSM, if using the perimeter detect features, prime your p
 <p>The quickest way to get started is to see the various methods at work by running these scripts:
 <code>python /usr/local/share/zymkey/examples/zk_app_utils_test.py</code>
 <code>python /usr/local/share/zymkey/examples/zk_crypto_test.py</code></p>
-<p>More Resources:</p>
-<ul>
-<li><a href="https://community.zymbit.com/">Community Forum</a></li>
-<li><a href="https://docs.zymbit.com/tutorials/encrypt-rfs/hsm4">LUKS filesystem encryption</a></li>
-<li><a href="https://docs.zymbit.com/tutorials/sensor-data/">Encrypting &amp; decrypting sensor data on disk</a></li>
-<li><a href="https://docs.zymbit.com/reference/real-time-clock/">Real Time Clock</a></li>
-</ul>
+

--- a/content/getting-started/hsm4/quickstart/index.md
+++ b/content/getting-started/hsm4/quickstart/index.md
@@ -16,7 +16,7 @@ toc: true
 
 * Raspberry Pi 3 or 4, if using Raspberry Pi.
 * Raspbian or Ubuntu/ Tegra is installed.
-    * Other Linux distributions will work, but may require extra configuration. We will gladly provide guidance, but cannot guarantee support. For information see the [Operating Systems](https://community.zymbit.com/c/23) Community Forum.
+    * Other Linux distributions will work, but may require extra configuration. We will gladly provide guidance, but cannot guarantee support. For information on supported operating systems, see [Operating Systems](https://docs.zymbit.com/troubleshooting/general/#q-which-operating-systems-does-zymbit-support).
 * Adequate power supply is used (5V).
     * **For Pi users:** if the Red Power LED on the Pi is not illuminated this means the supply voltage is inadequate.
     * More info [here](https://docs.zymbit.com/reference/power-quality/).
@@ -72,23 +72,22 @@ Now power up the Pi and you will see a blue LED blinking rapidly and consistentl
 <img src="HSM4-LED-5times-per-second.gif" alt="HSM4-LED-5times-per-second" width="25%">
 
 ----------
-
 ## 4. Turn on the I2C Bus
 
 For the Jetson, the Operating System - Tegra - is based on Ubuntu. The I2C bus is enabled by default. There are no additional steps required.
 
-For the RPi, follow these steps to enable the I2C bus:
-1. Log in to your pi and run `sudo raspi-config`
-2. Select Interfacing Options -> I2C -> 
-Would you like the ARM I2C interface to be enabled? select  (Yes), enter, enter
-3. Arrow Right to Finish
+For Raspian-based operating systems, you must configure the state of the {{< term/i2c >}}.
+
+Log in to your Raspberry Pi and run sudo raspi-config.
+Navigate to Interfacing Options -> I2C -> Would you like the ARM I2C interface to be enabled?
+Select yes, and confirm this choice.
+Your {{< term/i2c >}} bus is now configured and ready to talk to the Zymkey. The default {{< term/i2c >}} address for the Zymkey is 0x30.
+
+{{< resource_link "troubleshooting/zymkey4/#q-how-do-i-set-an-alternative-i2c-address" >}} The default I2C address for Zymkey is 0x30. If this conflicts with another device in your system, you can reconfigure the Zymkey to use another address of your choice. {{< /resource_link >}}
 
 Your I2C bus is now on and ready to talk to the HSM.
 
-The default I2C address for HSM is 0x30. If needed, you can [change the I2C Address](https://docs.zymbit.com/quickstart/faq/hsm4/#q-how-do-i-set-an-alternative-i2c-address) after following steps 5 and 6.
-
 ----------
-
 ## 5. Install Software Packages and API
 
 The Zymbit install process uses curl which is not included with Tegra (Ubuntu 18.04) by default. 
@@ -96,40 +95,47 @@ Install curl: sudo apt install curl
 
 For a bare Raspbian system, first login to your Pi.
 
-Then download and install the necessary Zymbit services onto your Pi. 
+Then download and install the necessary Zymbit services onto your Pi.  
 `curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash`
 
 
 (grab a cup of coffee because this will take between 4 and 20 minutes).
 
+----------
+## 6. Application Examples
 
+The quickest way to get started is to see the Zymkey's various features at work by running these test scripts that were installed with the client software:
+
+`python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`  
+`python3 /usr/local/share/zymkey/examples/zk_crypto_test.py`
+
+The example scripts are missing in focal and bullseye distributions. You can get the example scripts from here:
+
+[Download example files](https://community.zymbit.com/t/installation-missing-files/1331/2?u=bob_of_zymbit)
+
+Now you're ready to start developing with the Zymbit module.
 
 ----------
-## 6. Developer Mode (temporary binding)
+## 7. Developer Mode (temporary binding)
 When the software installation has completed, reboot. After rebooting, the Pi/ Jetson will temporarily bind the HSM to itself. Once bound, the blue LED should blink once every 3 seconds.
 
 <img src="HSM4-LED-every-3-seconds.gif" alt="HSM4-LED-every-3-seconds" width="25%">
 
 Your HSM is now in Developer Mode. The binding is temporary and the HSM can be moved to another host device and the binding process repeated. Now is the time to prototype. Do all development work with the HSM in this mode. You can safely test the self-destruct features here. A self-destruct in this mode will stop all HSM functionality until the host is rebooted. Only in production mode will the HSM actually self-destruct.
 
-Before moving on to Production mode, ensure your application is running correctly. Explore our HSM resources for help: 
+Before moving on to Production mode, ensure your application is running correctly. 
+
+Explore our HSM resources for help: 
 * [Perimeter Detect](https://docs.zymbit.com/tutorials/perimeter-detect/hsm4)
 * [Encrypting your root file system](https://docs.zymbit.com/tutorials/encrypt-rfs/hsm4)
 * [Encrypting & decrypting sensor data on disk](https://docs.zymbit.com/tutorials/sensor-data/)
 * [Using the Real Time Clock](https://docs.zymbit.com/reference/real-time-clock/)
 * [Zymbit APIs](https://docs.zymbit.com/quickstart/api/).
 
-If you have any questions, feel free to create a new post here in the Community and we will get back to you.
-
-
-To test some of the API and see it's functionality, you can also run these pre-installed scripts: 
-
-`python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`
-
-`python3 /usr/local/share/zymkey/examples/zk_crypto_test.py`
+If you have any questions, feel free to create a new post in the Community and we will get back to you.
 
 ----------
-## 7. Production Mode (permanent binding)
+## 8. Production Mode (permanent binding)
 
 When you are ready to deploy your system into the field we recommend that you permanently bind your HSM to a specific host device and SD card.
 
@@ -313,23 +319,5 @@ After bind locking the HSM, if using the perimeter detect features, prime your p
 5.  **Your system is now armed.**
 
 
-## <span class="markdown-h2 include-toc">Additional Resources</span>
 
-<h3 id="troubleshooting">Troubleshooting</h3>
-<ul>
-<li><a href="https://docs.zymbit.com/quickstart/faq/hsm4/#troubleshooting">HSM4 Troubleshooting FAQ</a></li>
-<li><a href="https://community.zymbit.com/">Community Forum</a></li>
-</ul>
-
-<h3 id="perimeter-detect">Perimeter Detect</h3>
-<p>Refer to <a href="https://docs.zymbit.com/tutorials/perimeter-detect/hsm4">Using Perimeter Detect</a></p>
-
-<h3 id="api-documentation">API Documentation</h3>
-<p>API&#39;s are available for Python, C, C++
-<a href="https://docs.zymbit.com/quickstart/api">Go to API Documents &gt;</a>  </p>
-
-<h3 id="application-examples">Application Examples</h3>
-<p>The quickest way to get started is to see the various methods at work by running these scripts:
-<code>python /usr/local/share/zymkey/examples/zk_app_utils_test.py</code>
-<code>python /usr/local/share/zymkey/examples/zk_crypto_test.py</code></p>
 

--- a/content/getting-started/hsm6/quickstart/index.md
+++ b/content/getting-started/hsm6/quickstart/index.md
@@ -16,7 +16,7 @@ toc: true
 
 * Raspberry Pi 3 or 4, if using Raspberry Pi.
 * Raspbian or Ubuntu/ Tegra is installed.
-    * Other Linux distributions will work, but may require extra configuration. We will gladly provide guidance, but cannot guarantee support. For information see the [Operating Systems](https://community.zymbit.com/c/23) Community Forum.
+    * Other Linux distributions will work, but may require extra configuration. We will gladly provide guidance, but cannot guarantee support. For information on supported operating systems, see [Operating Systems](https://docs.zymbit.com/troubleshooting/general/#q-which-operating-systems-does-zymbit-support).
 * Adequate power supply is used (5V).
     * **For Pi users:** if the Red Power LED on the Pi is not illuminated this means the supply voltage is inadequate.
     * More info [here](https://docs.zymbit.com/reference/power-quality/).
@@ -77,15 +77,16 @@ Now power up the Pi and you will see a blue LED blinking rapidly and consistentl
 
 For the Jetson, the Operating System - Tegra - is based on Ubuntu. The I2C bus is enabled by default. There are no additional steps required.
 
-For the RPi, follow these steps to enable the I2C bus:
-1. Log in to your pi and run `sudo raspi-config`
-2. Select Interfacing Options -> I2C -> 
-Would you like the ARM I2C interface to be enabled? select  (Yes), enter, enter
-3. Arrow Right to Finish
+For Raspian-based operating systems, you must configure the state of the {{< term/i2c >}}.
+
+Log in to your Raspberry Pi and run `sudo raspi-config`.  
+Navigate to Interfacing Options -> I2C -> Would you like the ARM I2C interface to be enabled?  
+Select yes, and confirm this choice.  
+Your {{< term/i2c >}} bus is now configured and ready to talk to the Zymkey. The default {{< term/i2c >}} address for the Zymkey is 0x30.
+
+{{< resource_link "troubleshooting/zymkey4/#q-how-do-i-set-an-alternative-i2c-address" >}} The default I2C address for Zymkey is 0x30. If this conflicts with another device in your system, you can reconfigure the Zymkey to use another address of your choice. {{< /resource_link >}}
 
 Your I2C bus is now on and ready to talk to the HSM.
-
-The default I2C address for HSM is 0x30. If needed, you can [change the I2C Address](https://docs.zymbit.com/quickstart/faq/hsm6/#q-how-do-i-set-an-alternative-i2c-address) after following steps 5 and 6.
 
 ----------
 
@@ -96,13 +97,27 @@ Install curl: sudo apt install curl
 
 For a bare Raspbian system, first login to your Pi.
 
-Then download and install the necessary Zymbit services onto your Pi. 
+Then download and install the necessary Zymbit services onto your Pi.  
 `curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash`
 
 (grab a cup of coffee because this will take between 4 and 20 minutes).
 
 ----------
-## 6. Developer Mode (temporary binding)
+## 6. Application Examples
+
+The quickest way to get started is to see the Zymkey's various features at work by running these test scripts that were installed with the client software:
+
+`python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`  
+`python3 /usr/local/share/zymkey/examples/zk_crypto_test.py`
+
+The example scripts are missing in focal and bullseye distributions. You can get the example scripts from here:
+
+[Download example files](https://community.zymbit.com/t/installation-missing-files/1331/2?u=bob_of_zymbit)
+
+Now you're ready to start developing with the Zymbit module.
+
+----------
+## 7. Developer Mode (temporary binding)
 When the software installation has completed, reboot. After rebooting, the Pi/ Jetson will temporarily bind the HSM to itself. Once bound, the blue LED should blink once every 3 seconds.
 
 <img src="HSM4-LED-every-3-seconds.gif" alt="HSM4-LED-every-3-seconds" width="25%">
@@ -112,34 +127,27 @@ Your HSM is now in Developer Mode. The binding is temporary and the HSM can be m
 Before moving on to Production mode, ensure your application is running correctly. Explore our HSM resources for help: 
 
 * [Perimeter Detect](https://docs.zymbit.com/tutorials/perimeter-detect/hsm6)
-* [Encrypting your root file system](https://docs.zymbit.com/tutorials/encrypt-rfs/hsm6)
+* [Encrypting your root file system](https://docs.zymbit.com/tutorials/encrypt-rfs/)
 * [Encrypting & decrypting sensor data on disk](https://docs.zymbit.com/tutorials/sensor-data/)
 * [Using the Real Time Clock](https://docs.zymbit.com/reference/real-time-clock/)
 * [Zymbit APIs](https://docs.zymbit.com/quickstart/api/).
 
 If you have any questions, feel free to create a new post here in the Community and we will get back to you.
 
-
-To test some of the API and see it's functionality, you can also run these pre-installed scripts: 
-
-`python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`
-
-`python3 /usr/local/share/zymkey/examples/zk_crypto_test.py`
-
 ----------
-## 7. Production Mode (permanent binding)
+## 8. Production Mode (permanent binding)
 
 When you are ready to deploy your system into the field we recommend that you permanently bind your HSM to a specific host device and SD card.
 
-##### **WARNING: THIS BINDING PROCESS IS PERMANENT AND CANNOT BE REVERSED. PAY ATTENTION TO THE FOLLOWING:**
-* Your specific HSM will be locked to the specific host device and it is impossible to move or bind your HSM to another host. There are no factory resets, masterkeys or other forms of recovery. 
+{{< callout destructive >}} THE BINDING PROCESS IS PERMANENT AND CANNOT BE REVERSED. PAY ATTENTION TO THE FOLLOWING:
 
-* If you are using the perimeter_detect features, the sequence in which you arm, disarm is very important in production mode. Be sure to follow the process steps below.
+Your specific HSM will be permanently locked to the specific host device.
+It will be impossible to move or bind your HSM to another device. There are no factory resets, masterkeys, or other forms of recovery.
+If you are using the Perimeter Detect features, then the sequence in which you arm and disarm this feature is very important. Be sure to carefully follow the process steps below.
+Once you have locked your HSM into production mode, Zymbit cannot guarantee its operation if you subsequently do a major distribution upgrade (e.g. Raspbian Buster to Bullseye). Contact Zymbit for more information.
+If you decide that you are not ready for permanent binding, leave the HSM4 in developer mode, but beware this makes it easier for a bad actor to replace the host with rogue hardware.
 
-
-* Once you have locked your HSM into production mode, Zymbit cannot guarantee its operation if you subsequently do a major distribution upgrade (e.g. Raspbian Jessie to Stretch). [Contact Zymbit for more information.](https://www.zymbit.com/contact-us/)
-
-* If you decide that you are not ready for permanent binding then leave it in developer mode, but beware this makes it easier for a bad actor to replace the host with rogue hardware.
+{{< /callout >}}
 
 ##### **Moving from Developer Mode to Production Mode**
 **Pre-binding Checklist**
@@ -309,31 +317,3 @@ After bind locking the HSM, if using the perimeter detect features, prime your p
 3.    Get Perimeter Detect Info to confirm prior events are cleared and the perimeter is closed.
 4.    If the Perimeter Detect Event returns clear, then you can ‘arm your system’ as you require by setting Set Perimeter Event Actions to “none”, “notify” or “selfdestruct” (You can only do this once!).
 5.  **Your system is now armed.**
-
-## <span class="markdown-h2 include-toc">Additional Resources</span>
-
-<h3 id="troubleshooting">Troubleshooting</h3>
-<ul>
-<li><a href="https://docs.zymbit.com/quickstart/faq/hsm6/#troubleshooting">HSM6 Troubleshooting FAQ</a></li>
-<li><a href="https://community.zymbit.com/">Community Forum</a></li>
-</ul>
-
-<h3 id="perimeter-detect">Perimeter Detect</h3>
-<p>Refer to <a href="https://docs.zymbit.com/tutorials/perimeter-detect/hsm6">Using Perimeter Detect</a></p>
-
-<h3 id="api-documentation">API Documentation</h3>
-<p>API&#39;s are available for Python, C, C++
-<a href="https://docs.zymbit.com/quickstart/api">Go to API Documents &gt;</a>  </p>
-
-<h3 id="application-examples">Application Examples</h3>
-<p>The quickest way to get started is to see the various methods at work by running these scripts:
-<code>python /usr/local/share/zymkey/examples/zk_app_utils_test.py</code>
-<code>python /usr/local/share/zymkey/examples/zk_crypto_test.py</code></p>
-<p>More Resources:</p>
-<ul>
-<li><a href="https://community.zymbit.com/">Community Forum</a></li>
-<li><a href="https://docs.zymbit.com/tutorials/encrypt-rfs/hsm6">LUKS filesystem encryption</a></li>
-<li><a href="https://docs.zymbit.com/tutorials/sensor-data/">Encrypting &amp; decrypting sensor data on disk</a></li>
-<li><a href="https://docs.zymbit.com/reference/real-time-clock/">Real Time Clock</a></li>
-</ul>
-

--- a/content/getting-started/zymkey4/quickstart/index.md
+++ b/content/getting-started/zymkey4/quickstart/index.md
@@ -162,8 +162,12 @@ In production mode, Zymkey generates a unique Device ID by measuring certain att
 
 The quickest way to get started is to see the Zymkey's various features at work by running these test scripts that were installed with the client software:
 
-* `python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`
-* `python3 /usr/local/share/zymkey/examples/zk_crypto_test.py`
+`python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`  
+`python3 /usr/local/share/zymkey/examples/zk_crypto_test.py`
+
+The example scripts are missing in focal and bullseye distributions. You can get the example scripts from here:
+
+[Download example files](https://community.zymbit.com/t/installation-missing-files/1331/2?u=bob_of_zymbit)
 
 Now you're ready to start developing with Zymkey4 and Raspberry Pi. When it's time to deploy your project, read our guide on enabling Production Mode:
 


### PR DESCRIPTION
Fixed broken links on HSM pages and added a link to grab example files for bullseye and focal distros that did not include the example files by default (known bug).