### PR TITLE
Bg 64bit flag

### DIFF
--- a/content/getting-started/hsm4/quickstart/index.md
+++ b/content/getting-started/hsm4/quickstart/index.md
@@ -150,6 +150,13 @@ How to set cpu governor to performance.
 
 Login to your host device and follow these steps to install the HSM's client software.
 
+{{% callout notice %}}
+As of March 2023, Raspberry PI OS 32-bit images install the 64-bit kernel along with the 32-bit root filesystem. This does not allow our installation script to work. In order to properly install on an 32-bit system, edit `/boot/config.txt` and add the following line to the bottom of the file, then reboot.
+
+`arm_64bit=0`
+
+{{% /callout %}}
+
 The HSM will require a number of packages to be installed from the Raspbian and Zymbit `apt` repositories. The following setup script will be install a number of files and software packages on your system, including:
 
 * Zymbit `.service` files located in the `/etc/systemd/system` directory

--- a/content/getting-started/hsm6/quickstart/index.md
+++ b/content/getting-started/hsm6/quickstart/index.md
@@ -147,6 +147,13 @@ How to set cpu governor to performance.
 
 Login to your host device and follow these steps to install the HSM's client software.
 
+{{% callout notice %}}
+As of March 2023, Raspberry PI OS 32-bit images install the 64-bit kernel along with the 32-bit root filesystem. This does not allow our installation script to work. In order to properly install on an 32-bit system, edit `/boot/config.txt` and add the following line to the bottom of the file, then reboot.
+
+`arm_64bit=0`
+
+{{% /callout %}}
+
 The HSM will require a number of packages to be installed from the Raspbian and Zymbit `apt` repositories. The following setup script will be install a number of files and software packages on your system, including:
 
 * Zymbit `.service` files located in the `/etc/systemd/system` directory

--- a/content/getting-started/zymkey4/quickstart/index.md
+++ b/content/getting-started/zymkey4/quickstart/index.md
@@ -139,7 +139,7 @@ How to set cpu governor to performance.
 Login to your host device and follow these steps to install the ZYMKEY4's client software.
 
 {{% callout notice %}}
-As of March 2023, Raspberry PI OS 32-bit images install the 64-bit kernel along with the 32-bit root filesystem. This does not allow our installation script to work. In order to properly install on an 32-bit system, edit `/boot/config.txt` and add the follwing line to the bottom of the file, then reboot.
+As of March 2023, Raspberry PI OS 32-bit images install the 64-bit kernel along with the 32-bit root filesystem. This does not allow our installation script to work. In order to properly install on an 32-bit system, edit `/boot/config.txt` and add the following line to the bottom of the file, then reboot.
 
 `arm_64bit=0`
 

--- a/content/getting-started/zymkey4/quickstart/index.md
+++ b/content/getting-started/zymkey4/quickstart/index.md
@@ -5,7 +5,7 @@ description: ""
 aliases:
     - /quickstart/getting-started/zymkey4/
 date: ""
-lastmod: "03-21-2023"
+lastmod: "05-26-2023"
 draft: false
 images: []
 weight: 1
@@ -137,6 +137,13 @@ How to set cpu governor to performance.
 ## Install the client software
 
 Login to your host device and follow these steps to install the ZYMKEY4's client software.
+
+{{% callout notice %}}
+As of March 2023, Raspberry PI OS 32-bit images install the 64-bit kernel along with the 32-bit root filesystem. This does not allow our installation script to work. In order to properly install on an 32-bit system, edit `/boot/config.txt` and add the follwing line to the bottom of the file, then reboot.
+
+`arm_64bit=0`
+
+{{% /callout %}}
 
 The ZYMKEY4 will require a number of packages to be installed from the Raspbian and Zymbit `apt` repositories. The following setup script will be install a number of files and software packages on your system, including:
 


### PR DESCRIPTION
In March 2023, PI OS changed to load the 64bit kernel by default, even with 32bit images. Their "fix" to load the 32bit kernel instead is to include `arm_64bit=0` in /boot/config.txt. Added a note to the quickstart guides for Zymkey, HSM4, and HSM6.