### PR TITLE
Update GPG messages

### DIFF
--- a/content/troubleshooting/general/index.md
+++ b/content/troubleshooting/general/index.md
@@ -50,7 +50,6 @@ sudo pip3 install zku --upgrade
 The Zymbit GPG key expired and was renewed on September 30, 2024. New installations should not have any problems. `apt-get update` may complain that the GPG key has expired. To update your local key, do the following:
 
 ```bash
-sudo su
 curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
 ```
 

--- a/content/troubleshooting/general/index.md
+++ b/content/troubleshooting/general/index.md
@@ -1,7 +1,7 @@
 ---
 title: "General FAQ & Troubleshooting"
 linkTitle: "General"
-lastmod: "03-21-2023"
+lastmod: "2024-09-30"
 draft: false
 images: []
 weight: 10
@@ -47,11 +47,11 @@ sudo pip3 install zku --upgrade
 
 #### Expired GPG Key Preventing Access to Repository
 
-The Zymbit GPG key expired and was renewed on September 30, 2022. New installations should not have any problems. `apt-get update` may complain that the GPG key has expired. To update your local key, do the following:
+The Zymbit GPG key expired and was renewed on September 30, 2024. New installations should not have any problems. `apt-get update` may complain that the GPG key has expired. To update your local key, do the following:
 
 ```bash
 sudo su
-curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | apt-key add -
+curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
 ```
 
 #### Wake-Pin Issues for upgrades to Kernel 6.6 and later

--- a/content/troubleshooting/hsm4/index.md
+++ b/content/troubleshooting/hsm4/index.md
@@ -404,7 +404,9 @@ A: For Zymkey and HSMs, kernel drivers and libraries for all of the devices are 
 
 A: You can update your existing key with the following command:
 
- curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
+```bash
+curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
+```
 
 -----
 

--- a/content/troubleshooting/hsm4/index.md
+++ b/content/troubleshooting/hsm4/index.md
@@ -404,7 +404,7 @@ A: For Zymkey and HSMs, kernel drivers and libraries for all of the devices are 
 
 A: You can update your existing key with the following command:
 
-`curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | apt-key add -`
+ curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
 
 -----
 

--- a/content/troubleshooting/hsm6/index.md
+++ b/content/troubleshooting/hsm6/index.md
@@ -404,7 +404,9 @@ A: For Zymkey and HSMs, kernel drivers and libraries for all of the devices are 
 
 A: You can update your existing key with the following command:
 
- curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
+```bash
+curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
+```
 
 -----
 

--- a/content/troubleshooting/hsm6/index.md
+++ b/content/troubleshooting/hsm6/index.md
@@ -404,7 +404,7 @@ A: For Zymkey and HSMs, kernel drivers and libraries for all of the devices are 
 
 A: You can update your existing key with the following command:
 
-`curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | apt-key add -`
+ curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
 
 -----
 

--- a/content/troubleshooting/zymkey4/index.md
+++ b/content/troubleshooting/zymkey4/index.md
@@ -403,7 +403,7 @@ A: For Zymkey and HSMs, kernel drivers and libraries for all of the devices are 
 
 A: You can update your existing key with the following command:
 
-`curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | apt-key add -`
+ curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
 
 -----
 

--- a/content/troubleshooting/zymkey4/index.md
+++ b/content/troubleshooting/zymkey4/index.md
@@ -403,7 +403,9 @@ A: For Zymkey and HSMs, kernel drivers and libraries for all of the devices are 
 
 A: You can update your existing key with the following command:
 
+```bash
  curl -L https://zk-sw-repo.s3.amazonaws.com/apt-zymkey-pubkey.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/zymbit.gpg
+```
 
 -----
 


### PR DESCRIPTION
Our GPG key expired Sept 30 2024. The note on how to reload an updated key referenced deprecated apt-key command. Updated troubleshooting notes to use new keyring procedures.