### PR TITLE
Add prelim reference to Interposer

### DIFF
--- a/content/reference/product-briefs/hsm64.md
+++ b/content/reference/product-briefs/hsm64.md
@@ -17,7 +17,7 @@ toc: False
 
 * 1-to-3 USB Hub 2.0 support 
 
-* SEN 400 support with POE (suggested good POE injector, such as [tp-link POE160S](https://www.tp-link.com/us/business-networking/surveillance-switch/tl-poe160s/))
+* SEN 400 support with POE (suggested good POE injector: [tp-link POE160S](https://www.tp-link.com/us/business-networking/surveillance-switch/tl-poe160s/))
 
 * Optionally pre-loaded with Raspberry Pi OS Bookworm, Bullseye, or Ubuntu 22.04 Server; Zymbit software, root file system encrypted at factory. Ready to go out of the box.
 

--- a/content/reference/product-briefs/hsm64.md
+++ b/content/reference/product-briefs/hsm64.md
@@ -1,14 +1,11 @@
 ---
-title: "HSM64 Product Brief"
+title: "HSM64 Product Brief (preliminary)"
 linkTitle: "HSM64"
 draft: false
 weight: 300
-description: "HSM64 Preliminary Product Brief"
 toc: False
 
 ---
-
-## Features of the HSM6
 
 * Functionally equivalent to the HSM6
   * See: [HSM6 Product Information](https://www.zymbit.com/hsm6/)
@@ -20,5 +17,5 @@ toc: False
 
 * USB Hub 2.0
 
-* SEN support with POE 
+* SEN support with POE (suggested good POE injector, such as [tp-link POE160S](https://www.tp-link.com/us/business-networking/surveillance-switch/tl-poe160s/))
 

--- a/content/reference/product-briefs/hsm64.md
+++ b/content/reference/product-briefs/hsm64.md
@@ -11,15 +11,17 @@ toc: False
   * [HSM6 Product Information](https://www.zymbit.com/hsm6/)
   * [HSM6 Product Brief](https://www.zymbit.com/datasheets/hsm6)
 
-* Mates directly under the CM4. Standard GPIO header free for Pi HAT.
+* Mates directly under the CM4 leaving the standard GPIO header free for Pi HAT.
 
-* Ability to Rpiboot
+* Full support in place for CM4 programming via Rpiboot
 
 * 1-to-3 USB Hub 2.0 support 
 
 * SEN 400 support with POE (suggested good POE injector, such as [tp-link POE160S](https://www.tp-link.com/us/business-networking/surveillance-switch/tl-poe160s/))
 
-# Useful Links relevant to the HSM64
+* Optionally pre-loaded with Raspberry Pi OS Bookworm, Bullseye, or Ubuntu 22.04 Server; Zymbit software, root file system encrypted at factory. Ready to go out of the box.
+
+### Useful Links for the HSM64
   * [Bootware](https://docs.zymbit.com/bootware). References for HSM6 will apply to the HSM 64.
   * [API Interface](https://docs.zymbit.com/api). References for HSM6 will apply to the HSM 64.
   * [Secure Edge Node 400](https://www.zymbit.com/secure-edge-node-400/).

--- a/content/reference/product-briefs/hsm64.md
+++ b/content/reference/product-briefs/hsm64.md
@@ -1,0 +1,24 @@
+---
+title: "HSM64 Product Brief"
+linkTitle: "HSM64"
+draft: false
+weight: 300
+description: "HSM64 Preliminary Product Brief"
+toc: False
+
+---
+
+## Features of the HSM6
+
+* Functionally equivalent to the HSM6
+  * See: [HSM6 Product Information](https://www.zymbit.com/hsm6/)
+  * [HSM6 Product Brief](https://www.zymbit.com/datasheets/hsm6)
+
+* Integrates with CM4. Mates directly under the CM4, freeing up space for HATs on standard GPIO header
+
+* Ability to Rpiboot
+
+* USB Hub 2.0
+
+* SEN support with POE 
+

--- a/content/reference/product-briefs/hsm64.md
+++ b/content/reference/product-briefs/hsm64.md
@@ -1,6 +1,6 @@
 ---
-title: "HSM64 Product Brief (preliminary)"
-linkTitle: "HSM64"
+title: "HSM 64 Product Brief"
+linkTitle: "HSM 64"
 draft: false
 weight: 300
 toc: False
@@ -8,14 +8,19 @@ toc: False
 ---
 
 * Functionally equivalent to the HSM6
-  * See: [HSM6 Product Information](https://www.zymbit.com/hsm6/)
+  * [HSM6 Product Information](https://www.zymbit.com/hsm6/)
   * [HSM6 Product Brief](https://www.zymbit.com/datasheets/hsm6)
 
-* Integrates with CM4. Mates directly under the CM4, freeing up space for HATs on standard GPIO header
+* Mates directly under the CM4. Standard GPIO header free for Pi HAT.
 
 * Ability to Rpiboot
 
-* USB Hub 2.0
+* 1-to-3 USB Hub 2.0 support 
 
-* SEN support with POE (suggested good POE injector, such as [tp-link POE160S](https://www.tp-link.com/us/business-networking/surveillance-switch/tl-poe160s/))
+* SEN 400 support with POE (suggested good POE injector, such as [tp-link POE160S](https://www.tp-link.com/us/business-networking/surveillance-switch/tl-poe160s/))
+
+# Useful Links relevant to the HSM64
+  * [Bootware](https://docs.zymbit.com/bootware). References for HSM6 will apply to the HSM 64.
+  * [API Interface](https://docs.zymbit.com/api). References for HSM6 will apply to the HSM 64.
+  * [Secure Edge Node 400](https://www.zymbit.com/secure-edge-node-400/).
 


### PR DESCRIPTION
Putting a placeholder page up for the HSM64 / Interposer as a landing for links to HSM6, etc. First units going out this week for eval.