### PR TITLE
Core name cleanup

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -24,7 +24,7 @@ Welcome to Zymbit’s Documentation Site! Here, you will find all the resources 
 Bootware® 1.3 Release (1.3.0-1):
 - Features:
   - #173 Add support for CM5 (ZYMKEY, HSM4, HSM6)
-  - #174 Add second layer key verification of zi image to zboot. NOTE: This additional check requires updating 1.2.2 and earlier images by running `zbcli imager` from version 1.3.0-1.
+  - #174 Add second layer key verification of zi image to zboot. NOTE: This additional check requires updating 1.2.2 and earlier images by running `zbcli imager` from version 1.3.0-1. See [1.3.0 upgrade](./bootware1.3/troubleshooting/#release-130-1)
   - #175 Add splashscreen to zboot
 - Bug Fixes
   - #171 SAS token truncated at first "="
@@ -73,7 +73,7 @@ The Zymbit Products also include Bookworm 64-bit support.
 
 #### Other significant enhancements in Bootware 1.1:
 
-**Issue #142** - FIXED. OS updates that change boot.scr can prevent future boot. Affects Ubuntu. Although the PI version of Ubuntu does not use U-Boot, Ubuntu's dpkg kernel update re-writes the file /boot/firmware/boot.scr. boot.scr was used by Bootware 1.0, and a re-write of the file could leave the system unable to boot. Bootware 1.1 no longer relies on the file. See [1.3.0 upgrade](./bootware1.3/troubleshooting/#release-130-1)
+**Issue #142** - FIXED. OS updates that change boot.scr can prevent future boot. Affects Ubuntu. Although the PI version of Ubuntu does not use U-Boot, Ubuntu's dpkg kernel update re-writes the file /boot/firmware/boot.scr. boot.scr was used by Bootware 1.0, and a re-write of the file could leave the system unable to boot. Bootware 1.1 no longer relies on the file. 
 
 **Enhancement** - The common data partition is now encrypted and the LUKS key is locked by the Zymbit HSM.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -73,7 +73,7 @@ The Zymbit Products also include Bookworm 64-bit support.
 
 #### Other significant enhancements in Bootware 1.1:
 
-**Issue #142** - FIXED. OS updates that change boot.scr can prevent future boot. Affects Ubuntu. Although the PI version of Ubuntu does not use U-Boot, Ubuntu's dpkg kernel update re-writes the file /boot/firmware/boot.scr. boot.scr was used by Bootware 1.0, and a re-write of the file could leave the system unable to boot. Bootware 1.1 no longer relies on the file.
+**Issue #142** - FIXED. OS updates that change boot.scr can prevent future boot. Affects Ubuntu. Although the PI version of Ubuntu does not use U-Boot, Ubuntu's dpkg kernel update re-writes the file /boot/firmware/boot.scr. boot.scr was used by Bootware 1.0, and a re-write of the file could leave the system unable to boot. Bootware 1.1 no longer relies on the file. See [1.3.0 upgrade](./bootware1.3/troubleshooting/#release-130-1)
 
 **Enhancement** - The common data partition is now encrypted and the LUKS key is locked by the Zymbit HSM.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -2,7 +2,7 @@
 title: "Zymbit Documentation"
 description: ""
 date: 2020-10-06T08:47:36+00:00
-lastmod: 2025-02-01
+lastmod: 2025-03-12
 draft: false
 images: []
 weight: 8
@@ -113,7 +113,7 @@ We have added support for Bookworm (64-bit) on the Pi5, PI4 and CM4 for the ZYMK
 
 #### October 2023
 -----
-Secure Compute Module moved from Revision A to Revision B. The Zymbit Software did not change. The root filesystem partitioning changed from 100% of the eMMC to 50% of the eMMC (encrypted). This was done to accommodate future support for Bootware, which is available in a Preview mode. A utility is included to repartition to 100% (encrypted) if required.
+Secure Compute Module moved from Revision A to Revision B. The Zymbit Core Software did not change. The root filesystem partitioning changed from 100% of the eMMC to 50% of the eMMC (encrypted). This was done to accommodate future support for Bootware, which is available in a Preview mode. A utility is included to repartition to 100% (encrypted) if required.
 
 See the [Troubleshooting/FAQ](troubleshooting/scm) for more information on the changes from Rev A to Rev B of the SCM itself.
 <br>

--- a/content/bootware1.3/archive/bootware-one-zero-general/features/development/index.md
+++ b/content/bootware1.3/archive/bootware-one-zero-general/features/development/index.md
@@ -23,7 +23,7 @@ Developing your applications on the CM4 allows you the freedom to start complete
 
 ### Steps
 1. Start with Bullseye or Ubuntu 22.04 image
-2. Load Zymbit software (a ZYMBIT HSM is not necessary)
+2. Load Zymbit Core Software (a ZYMBIT HSM is not necessary)
 3. Load/Install bootware tools
 4. Use zb-imager to create a zi image signed with software key
 5. Pre-configure the SCM with a known good A/B partition. This is just in case the CM4 image has any problem
@@ -33,9 +33,9 @@ Developing your applications on the CM4 allows you the freedom to start complete
 
 Follow the standard instructions from Raspberry Pi Foundation using `rpiboot` and the Pi Imager to load Bullseye Lite 64-bit or Ubuntu Server 22.04 (jammy). Load all of the necessary software and debug and test your application.
 
-### 2. Load the Zymbit software
+### 2. Load the Zymbit Core Software
 
-Once the image is put together and loaded on the SCM, load Zymbit software. For now, Zymbit hardware is not needed. You only need to complete the software installation. The following will load all packages and reboot to complete the software installation.
+Once the image is put together and loaded on the SCM, load Zymbit Core Software. For now, Zymbit hardware is not needed. You only need to complete the software installation. The following will load all packages and reboot to complete the software installation.
 
 ```bash
 curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash

--- a/content/bootware1.3/archive/bootware-one-zero-general/getting-started/_index.md
+++ b/content/bootware1.3/archive/bootware-one-zero-general/getting-started/_index.md
@@ -19,7 +19,7 @@ headless: false
 
 In this Getting Started guide we describe how to bring up a common use case for Bootware - A/B partitioning for fallback and recovery.
 
-The default SCM/SEN as shipped has Zymbit software pre-installed. The Zymbit product should be up and running with the blue LED flashing once every three seconds. All of the default images will have a hostname of zymbit-dev and a login of zymbit/zymbit. Change the hostname and login during your development.
+The default SCM/SEN as shipped has Zymbit Core Software pre-installed. The Zymbit product should be up and running with the blue LED flashing once every three seconds. All of the default images will have a hostname of zymbit-dev and a login of zymbit/zymbit. Change the hostname and login during your development.
 
 An HDMI console is highly recommended for setting up your unit with Bootware. The process of repartitioning and loading takes time and the console is handy for monitoring progress.
 

--- a/content/bootware1.3/archive/bootware-one-zero/features/development/index.md
+++ b/content/bootware1.3/archive/bootware-one-zero/features/development/index.md
@@ -23,7 +23,7 @@ Developing your applications on the CM4 allows you the freedom to start complete
 
 ### Steps
 1. Start with Bullseye or Ubuntu 22.04 image
-2. Load Zymbit software (a ZYMBIT HSM is not necessary)
+2. Load Zymbit Core Software (a ZYMBIT HSM is not necessary)
 3. Load/Install bootware tools
 4. Use zb-imager to create a zi image signed with software key
 5. Pre-configure the SCM with a known good A/B partition. This is just in case the CM4 image has any problem
@@ -33,9 +33,9 @@ Developing your applications on the CM4 allows you the freedom to start complete
 
 Follow the standard instructions from Raspberry Pi Foundation using `rpiboot` and the Pi Imager to load Bullseye Lite 64-bit or Ubuntu Server 22.04 (jammy). Load all of the necessary software and debug and test your application.
 
-### 2. Load the Zymbit software
+### 2. Load the Zymbit Core Software
 
-Once the image is put together and loaded on the SCM, load Zymbit software. For now, Zymbit hardware is not needed. You only need to complete the software installation. The following will load all packages and reboot to complete the software installation.
+Once the image is put together and loaded on the SCM, load Zymbit Core Software. For now, Zymbit hardware is not needed. You only need to complete the software installation. The following will load all packages and reboot to complete the software installation.
 
 ```bash
 curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash

--- a/content/bootware1.3/archive/bootware-one-zero/getting-started/_index.md
+++ b/content/bootware1.3/archive/bootware-one-zero/getting-started/_index.md
@@ -19,7 +19,7 @@ headless: false
 
 In this Getting Started guide we describe how to bring up a common use case for Bootware - A/B partitioning for fallback and recovery.
 
-The default SCM/SEN as shipped has Zymbit software pre-installed. The Zymbit product should be up and running with the blue LED flashing once every three seconds. All of the default images will have a hostname of zymbit-dev and a login of zymbit/zymbit. Change the hostname and login during your development.
+The default SCM/SEN as shipped has Zymbit Core Software pre-installed. The Zymbit product should be up and running with the blue LED flashing once every three seconds. All of the default images will have a hostname of zymbit-dev and a login of zymbit/zymbit. Change the hostname and login during your development.
 
 An HDMI console is highly recommended for setting up your unit with Bootware. The process of repartitioning and loading takes time and the console is handy for monitoring progress.
 

--- a/content/bootware1.3/features/development/index.md
+++ b/content/bootware1.3/features/development/index.md
@@ -20,7 +20,7 @@ Developing your applications on the CM4 allows you the freedom to start complete
 
 ### Steps
 1. Start with Bookworm, Bullseye or Ubuntu 22.04 image
-2. Load Zymbit software (a ZYMBIT HSM is not necessary)
+2. Load Zymbit Core Software (a ZYMBIT HSM is not necessary)
 3. Load/Install bootware tools
 4. Use `zbcli imager` to create a zi image signed with software key
 5. Pre-configure the SCM with a known good A/B partition. This is just in case the CM4 image has any problem
@@ -30,9 +30,9 @@ Developing your applications on the CM4 allows you the freedom to start complete
 
 Follow the standard instructions from Raspberry Pi Foundation using `rpiboot` and the Pi Imager to load Bookworm or Bullseye Lite 64-bit or Ubuntu Server 22.04 (jammy). Load all of the necessary software and debug and test your application.
 
-### 2. Load the Zymbit software
+### 2. Load the Zymbit Core Software
 
-Once the image is put together and loaded on the SCM, load Zymbit software. For now, Zymbit hardware is not needed. You only need to complete the software installation. The following will load all packages and reboot to complete the software installation.
+Once the image is put together and loaded on the SCM, load Zymbit Core Software. For now, Zymbit hardware is not needed. You only need to complete the software installation. The following will load all packages and reboot to complete the software installation.
 
 ```bash
 curl -G https://s3.amazonaws.com/zk-sw-repo/install_zk_sw.sh | sudo bash

--- a/content/bootware1.3/getting-started/_index.md
+++ b/content/bootware1.3/getting-started/_index.md
@@ -34,7 +34,7 @@ Step-by-step videos of this Getting-Started are also available.
 -----
 
 
-The default SCM/SEN as shipped has Zymbit software pre-installed. For setups using the ZYMKEY4 or other Zymbit HSMs, the installation is up to the user. The Zymbit product should be up and running with the blue LED flashing once every three seconds before installing Bootware. We recommend partitioning your /boot partition with a size of 512MB (default for Bookworm). The standard Zymbit encrytion process is not necessary as Bootware will do this for you. 
+The default SCM/SEN as shipped has Zymbit Core Software pre-installed. For setups using the ZYMKEY4 or other Zymbit HSMs, the installation is up to the user. The Zymbit product should be up and running with the blue LED flashing once every three seconds before installing Bootware. We recommend partitioning your /boot partition with a size of 512MB (default for Bookworm). The standard Zymbit encrytion process is not necessary as Bootware will do this for you. 
 
 A free ZYMKEY is available when you sign up for a Bootware trial. See [Get Bootware](https://www.zymbit.com/get-bootware)
 

--- a/content/bootware1.3/getting-started/_index.md
+++ b/content/bootware1.3/getting-started/_index.md
@@ -180,7 +180,7 @@ Next, you will be prompted for what type of image to make: A full image of the l
 
 You can optionally provide an image version. This is for your use in helping to identify the image later. It is not used in the process. 
 
-Next, you will be prompted for signing keys. Keys can be Software or Hardware based and are used for signing and verification of images. Software keys are supported on all Zymbit products. Hardware keys are supported with Secure Compute Module (SCM) or HSM6 products. Had we chosen earlier to include hardware key support, we would be asked to choose either hardware or software key support. We chose earlier to not include hardware key support. You can use an existing key or instruct the imager to create new ones for you. For this Quickstart, we will generate a new Software key. Select `Create new software key`
+Next, you will be prompted for signing keys. Keys can be software or hardware based and are used for signing and verification of images. Software keys are supported on all Zymbit products. Hardware keys are supported with Secure Compute Module (SCM) or HSM6 products. Had we chosen earlier to include hardware key support, we would be asked to choose either hardware or software key support. We chose earlier to not include hardware key support. You can use an existing key or instruct the imager to create new ones for you. For this Quickstart, we will generate a new software key. Select `Create new software key`
 
 ```
 ? Select key ›

--- a/content/bootware1.3/image-files/index.md
+++ b/content/bootware1.3/image-files/index.md
@@ -2,7 +2,7 @@
 title: "Image Files"
 linkTitle: "Image Files" 
 description: "Links to pre-prepared download image files and keys"
-lastmod: "2025-02-09"
+lastmod: "2025-03-12"
 aliases:
     - /bootware/image-files/
 draft: false
@@ -29,7 +29,7 @@ Example images all have the hostname of zymbit-dev and a login of zymbit and a p
 
 Example images all have the hostname of zymbit-dev and a login of zymbit and a password of zymbit. Please change if using for anything other than development examples.
 
-> NOTE: 1.3.0 requires additional signature information that is not present in 1.2.2 and earlier zi images. Signature verification of 1.2.2 and earlier images will fail verification in zboot 1.3.0. Run `zbcli imager` to create new images if moving your existing 1.2.2 zi images to 1.3.0.
+> NOTE: 1.3.0 requires additional signature information that is not present in 1.2.2 and earlier zi images. Signature verification of 1.2.2 and earlier images will fail verification in zboot 1.3.0. Run `zbcli imager` to create new images if moving your existing 1.2.2 zi images to 1.3.0. See [1.3.0 upgrade](../troubleshooting/#release-130-1)
 
 | Item | Size | Description | 
 |------|------|--------------------------|

--- a/content/bootware1.3/troubleshooting/_index.md
+++ b/content/bootware1.3/troubleshooting/_index.md
@@ -23,7 +23,16 @@ toc: true
 > It is highly recommended to use a Pi with at least 4GB of RAM. Bootware requires approximately 700MB of RAM overhead for image verification and encryption. For HTTPS endpoints, the image must be 700MB smaller than your total RAM.
 
 
-### Issues
+### Issues and Notes
+
+#### Release 1.3.0-1
+
+* Bootware 1.3.0-1 requires updated images. zi images made with 1.2.2-1 or earlier will not work with 1.3.0-1, due to additional signature files in the 1.3.0-1 based images used for secondary verification step. Procedure for updating an image made with 1.2.2-1 or earlier:
+
+  1. Start with Bootware 1.2.2 installed on staging device.
+  2. Update staging device with existing 1.2.2 zi image.
+  3. Update staging device with Bootware 1.3.0-1
+  4. Create a new updated zi image with Bootware 1.3.0-1
 
 #### Release 1.2.2-1
 

--- a/content/bootware1.3/tutorials/index.md
+++ b/content/bootware1.3/tutorials/index.md
@@ -2,7 +2,7 @@
 title: "Tutorials and Videos"
 linkTitle: "Tutorials" 
 description: "Links to on-line tutorials and video material"
-lastmod: "2025-02-19"
+lastmod: "2025-03-12"
 aliases:
     - /bootware/tutorials
 
@@ -15,11 +15,19 @@ toc: true
 -----
 ### Bootware 1.3 Step-by-Step Getting Started
 
+#### Learn how to configure and use Zymbit Bootware on Raspberry Pi 4, 5, CM4, and CM5 devices. Create images, set up keys, encrypt filesystems, deploy images, and experiment with A/B switching.
+
+-----
+#### Part 1
+
 {{< youtube UZtX2LrRCMI >}}
+<br>
 
-
+-----
+#### Part 2
 
 {{< youtube gHyWR_hCGwQ >}}
+<br>
 
 -----
 

--- a/content/getting-started/hsm4/production-mode/index.md
+++ b/content/getting-started/hsm4/production-mode/index.md
@@ -40,7 +40,7 @@ Active production mode
 
 ## Develop your application
 
-To begin, ensure that you have followed the Getting Started guide for your HSM4 carefully to install the prerequisite client software:
+To begin, ensure that you have followed the Getting Started guide for your HSM4 carefully to install the prerequisite Zymbit Core Software:
 
 {{< resource_link "getting-started/hsm4" >}}
 Install your HSM4 to a Raspberry Pi running Raspbian or Ubuntu before moving to production mode.

--- a/content/getting-started/hsm4/quickstart/index.md
+++ b/content/getting-started/hsm4/quickstart/index.md
@@ -35,7 +35,7 @@ Installing the Hardware
 Establish an {{< term/i2c >}} connection
 :   Enable the {{< term/i2c >}} bus on the host device in order to be able to communicate with the HSM.
 
-Install the client software
+Install the Zymbit Core Software
 :   These utilities provided by Zymbit are necessary to interact with the hardware module.
 
 Test the installation
@@ -136,9 +136,9 @@ Your {{< term/i2c >}} bus is now configured and ready to talk to the HSM. The de
 
 Your I2C bus is now on and ready to talk to the HSM.
 
-## Install the client software
+## Install the Zymbit Core Software
 
-Login to your host device and follow these steps to install the HSM's client software.
+Login to your host device and follow these steps to install the HSM's Zymbit Core Software.
 
 The HSM will require a number of packages to be installed from the Raspbian and Zymbit `apt` repositories. The following setup script will be install a number of files and software packages on your system, including:
 
@@ -166,7 +166,7 @@ When the software installation has completed, the script will automatically rebo
 In production mode, HSM generates a unique Device ID by measuring certain attributes of the specific host and the HSM itself to permanently associate the two.
 {{< /resource_link >}}
 
-The quickest way to get started is to see the HSM's various features at work by running these test scripts that were installed with the client software:
+The quickest way to get started is to see the HSM's various features at work by running these test scripts that were installed with the Zymbit Core Software:
 
 ```bash
 python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py

--- a/content/getting-started/hsm6/production-mode/index.md
+++ b/content/getting-started/hsm6/production-mode/index.md
@@ -40,7 +40,7 @@ Active production mode
 
 ## Develop your application
 
-To begin, ensure that you have followed the Getting Started guide for your HSM6 carefully to install the prerequisite client software:
+To begin, ensure that you have followed the Getting Started guide for your HSM6 carefully to install the prerequisite Zymbit Core Software:
 
 {{< resource_link "getting-started/hsm6" >}}
 Install your HSM6 to a Raspberry Pi running Raspbian or Ubuntu before moving to production mode.

--- a/content/getting-started/hsm6/quickstart/index.md
+++ b/content/getting-started/hsm6/quickstart/index.md
@@ -35,7 +35,7 @@ Installing the Hardware
 Establish an {{< term/i2c >}} connection
 :   Enable the {{< term/i2c >}} bus on the host device in order to be able to communicate with the HSM.
 
-Install the client software
+Install the Zymbit Core Software
 :   These utilities provided by Zymbit are necessary to interact with the hardware module.
 
 Test the installation
@@ -134,9 +134,9 @@ Your {{< term/i2c >}} bus is now configured and ready to talk to the HSM. The de
 
 Your I2C bus is now on and ready to talk to the HSM.
 
-## Install the client software
+## Install the Zymbit Core Software
 
-Login to your host device and follow these steps to install the HSM's client software.
+Login to your host device and follow these steps to install the HSM's Zymbit Core Software.
 
 The HSM will require a number of packages to be installed from the Raspbian and Zymbit `apt` repositories. The following setup script will be install a number of files and software packages on your system, including:
 
@@ -160,7 +160,7 @@ When the software installation has completed, the script will automatically rebo
 In production mode, HSM generates a unique Device ID by measuring certain attributes of the specific host and the HSM itself to permanently associate the two.
 {{< /resource_link >}}
 
-The quickest way to get started is to see the HSM's various features at work by running these test scripts that were installed with the client software:
+The quickest way to get started is to see the HSM's various features at work by running these test scripts that were installed with the Zymbit Core Software:
 
 `python3 /usr/local/share/zymkey/examples/zk_app_utils_test.py`
 

--- a/content/getting-started/scm/quickstart/index.md
+++ b/content/getting-started/scm/quickstart/index.md
@@ -31,7 +31,7 @@ The Zymbit Secure Compute Module (SCM) is an all-in-one Linux compute module - s
  * Connect up the ethernet and 12V power. The unit is designed to run headless. You do not need a monitor, keyboard, or mouse. As shipped, the hostname is `zymbit-dev` and a user named `zymbit` can be used for SSH login. The default password for SSH is zymbit. Please change your password once you login. Console login has been disabled.
 
 {{< callout notice >}}
-All necessary Zymbit software has been pre-installed. No further installation is necessary. The pre-installed image is encrypted and cannot be replaced via `rpiboot` in the field. Please contact support@zymbit.com for assistance.
+All necessary Zymbit Core Software has been pre-installed. No further installation is necessary. The pre-installed image is encrypted and cannot be replaced via `rpiboot` in the field. Please contact support@zymbit.com for assistance.
 {{< /callout >}}
 
  * Monitor the Blue LED on the Zymbit SCM module. The total boot time as configured should take approximately 90 seconds from power on. It will go through the following stages:

--- a/content/getting-started/scm/quickstart/index.md
+++ b/content/getting-started/scm/quickstart/index.md
@@ -137,9 +137,9 @@ This only affects SCMs with firmware 01.02.02release. This does not affect the H
 * Easy to Scale
 * Pre-encrypted file system
 {{< callout notice >}}
-The pre-installed image is encrypted and cannot be replaced via `rpiboot` in the field. Bootware 1.0 can be used to replace Bullseye or Ubuntu 22.04 based Operating System images. See [Bootware](../../../bootware-one-zero) for details.
+The pre-installed image is encrypted and cannot be replaced via `rpiboot` in the field. Bootware can be used to replace supported Operating System images. See [Bootware](../../../bootware) for details.
 {{< /callout >}}
-* Pre-loaded Linux kernel (bullseye 64-bit or Ubuntu 22.04 64-bit)
+* Pre-loaded Operating System (bookworm, bullseye, or Ubuntu 22.04 64-bit)
 * Optionally Pre-load with customer software
 * Pre-defined file manifest & policies
 * Custom MAC OUID blocks available

--- a/content/getting-started/zymkey4/production-mode/index.md
+++ b/content/getting-started/zymkey4/production-mode/index.md
@@ -44,7 +44,7 @@ Active production mode
 *DO NOT* cut the lock tab yet.
 {{< /callout >}}
 
-To begin, ensure that you have followed the Getting Started guide for your ZYMKEY4 carefully to install the prerequisite client software:
+To begin, ensure that you have followed the Getting Started guide for your ZYMKEY4 carefully to install the prerequisite Zymbit Core Software:
 
 {{< resource_link "getting-started/zymkey4" >}}
 Install your ZYMKEY4 to a Raspberry Pi running Raspbian or Ubuntu before moving to production mode.

--- a/content/getting-started/zymkey4/quickstart/index.md
+++ b/content/getting-started/zymkey4/quickstart/index.md
@@ -49,7 +49,7 @@ Installing the hardware
 Establish an {{< term/i2c >}} connection
 :   Enable the {{< term/i2c >}} bus on the host device in order to be able to communicate with the ZYMKEY4.
 
-Install the client software
+Install the Zymbit Core Software
 :   These utilities provided by Zymbit are necessary to interact with the hardware module.
 
 Test the installation
@@ -126,9 +126,9 @@ Your {{< term/i2c >}} bus is now configured and ready to talk to the ZYMKEY4. Th
 The default I2C address for ZYMKEY4 is 0x30. If this conflicts with another device in your system, you can reconfigure the ZYMKEY4 to use another address of your choice.
 {{< /resource_link >}}
 
-## Install the client software
+## Install the Zymbit Core Software
 
-Login to your host device and follow these steps to install the ZYMKEY4's client software.
+Login to your host device and follow these steps to install the ZYMKEY4's Zymbit Core Software.
 
 The ZYMKEY4 will require a number of packages to be installed from the Raspbian and Zymbit `apt` repositories. The following setup script will be install a number of files and software packages on your system, including:
 

--- a/content/reference/product-briefs/hsm64.md
+++ b/content/reference/product-briefs/hsm64.md
@@ -19,7 +19,7 @@ toc: False
 
 * SEN 400 support with POE (suggested good POE injector: [tp-link POE160S](https://www.tp-link.com/us/business-networking/surveillance-switch/tl-poe160s/))
 
-* Optionally pre-loaded with Raspberry Pi OS Bookworm, Bullseye, or Ubuntu 22.04 Server; Zymbit software, root file system encrypted at factory. Ready to go out of the box.
+* Optionally pre-loaded with Raspberry Pi OS Bookworm, Bullseye, or Ubuntu 22.04 Server; Zymbit Core Software, root file system encrypted at factory. Ready to go out of the box.
 
 ### Useful Links for the HSM64
   * [Bootware](https://docs.zymbit.com/bootware). References for HSM6 will apply to the HSM 64.

--- a/content/troubleshooting/general/index.md
+++ b/content/troubleshooting/general/index.md
@@ -12,7 +12,7 @@ toc: true
 
 ### **Release Notes - Latest Release 1/13/2023 (RC-23.01)**
 
-We updated the common Zymbit software release common to all products: ZYMKEY4, HSM4, HSM6, and the new SCM-based product line. Existing customers can do an update/upgrade to get the latest code.
+We updated the common Zymbit Core Software release common to all products: ZYMKEY4, HSM4, HSM6, and the new SCM-based product line. Existing customers can do an update/upgrade to get the latest code.
 
 ```bash
 sudo apt-get update
@@ -65,7 +65,7 @@ sudo sed -i 's/^deb https/deb [signed-by=\/usr\/share\/keyrings\/zymbit.gpg] htt
 
 #### Wake-Pin Issues for upgrades to Kernel 6.6 and later
 
-The installation script takes care of the following for you. If you are doing a new installation, you should not have to worry about the following. If you already installed the Zymbit software and then upgraded the kernel to something beyond 6.6, please note the following.
+The installation script takes care of the following for you. If you are doing a new installation, you should not have to worry about the following. If you already installed the Zymbit Core Software and then upgraded the kernel to something beyond 6.6, please note the following.
 
 Raspberry PI OS Bookworm updated the kernel to version 6.6.y in March 2024. The kernel no longer overrides an upstream kernel decision to force the base number of the main GPIO controller to be global GPIO 0. If the WAKE_PIN number is not set, the ZYMKEY will not bind. You will see 5 flashes per second continuously.For RPI4, RPI5, and CM4 platforms, you will need to set the WAKE_PIN in the following manner:
 

--- a/content/troubleshooting/scm/index.md
+++ b/content/troubleshooting/scm/index.md
@@ -12,7 +12,7 @@ toc: true
 
 
 
-### Updated Release 10/10/2023 (RC-23.01 base software unchanged)
+### Updated Release 10/10/2023 (RC-23.01 Zymbit Core Software unchanged)
 
 Updated the SCM release to support the Rev B release of the SCM hardware.
 

--- a/content/tutorials/aws-iot/verify-sigs/index.md
+++ b/content/tutorials/aws-iot/verify-sigs/index.md
@@ -51,7 +51,7 @@ All these examples will be done via Python using the Python-ECDSA library.
 
 ## Prerequisites
 
- 1. Follow the [Getting Started guide](https://docs.zymbit.com/getting-started/) first, installing all baseline software.
+ 1. Follow the [Getting Started guide](https://docs.zymbit.com/getting-started/) first, installing all Zymbit Core Software.
  2. If you wish to try Signature validation on AWS, you need a [valid device certificate](https://docs.zymbit.com/tutorials/aws-iot/tls/) attached to your AWS account.
 3. The device certificate needs to have a policy attached giving it permission to publish data.
 

--- a/content/tutorials/digital-wallet/oversight-example/index.md
+++ b/content/tutorials/digital-wallet/oversight-example/index.md
@@ -27,7 +27,7 @@ This can be useful for handing a copy of a wallet to a financial advisor or some
     * [HSM6](https://www.zymbit.com/hsm6/)
     * [SCM ](https://www.zymbit.com/secure-compute-platform/)
 
-* Follow the [Getting Started guide](../../../getting-started) first, installing all baseline software.
+* Follow the [Getting Started guide](../../../getting-started) first, installing all Zymbit Core Software.
 
 * All code snippets written in this article are written using Python3. For more Zymbit API documentation (Python/C/C++) visit: [API Documentation](../../../api)
 

--- a/content/tutorials/digital-wallet/slip39-example/index.md
+++ b/content/tutorials/digital-wallet/slip39-example/index.md
@@ -44,7 +44,7 @@ SLIP39 generates groups and each of these groups can contain its own system of m
     * [HSM6](https://www.zymbit.com/hsm6/)
     * [SCM](https://www.zymbit.com/secure-compute-platform/) 
 
-*  Follow the [Getting Started guide](../../../getting-started/) first, installing all baseline software. 
+*  Follow the [Getting Started guide](../../../getting-started/) first, installing all Zymbit Core Software. 
 
 * All code snippets written in this article are written using python3. For more Zymbit API documentation (Python/C/C++) visit: [API Documentation](../../../api/)
 

--- a/content/tutorials/digital-wallet/wallet-example/index.md
+++ b/content/tutorials/digital-wallet/wallet-example/index.md
@@ -54,7 +54,7 @@ safe and locked away!
     * [HSM6](https://www.zymbit.com/hsm6/)
     * [SCM ](https://www.zymbit.com/secure-compute-platform/)
 
-* Follow the [Getting Started guide](../../../getting-started/) first, installing all baseline software.
+* Follow the [Getting Started guide](../../../getting-started/) first, installing all Zymbit Core Software.
 
 * All code snippets written in this article are written using python3. For more Zymbit API documentation (Python/C/C++) visit: [API Documentation](../../../api/)
 


### PR DESCRIPTION
- Standardized all software refs to Zymbit Core Software.
- Added steps to notes regarding incompatibility of 1.2.2 zi images with 1.3.0.
- Titles on Bootware tutorial videos